### PR TITLE
poller.cc: add missing header

### DIFF
--- a/src/poller.cc
+++ b/src/poller.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cassert>
+#include <numeric>
 
 #include "poller.hh"
 #include "util.hh"


### PR DESCRIPTION
Fails to compile on gcc6 without numeric header